### PR TITLE
Rewrite delta merging to combine file creation and non-contiguous deltas with fuzzy matches

### DIFF
--- a/git-sccsimport.py
+++ b/git-sccsimport.py
@@ -1147,7 +1147,7 @@ def ParseOptions(argv):
 	parser.add_option("--authormap",
 			  help="File mapping author user-IDs to Git style user.{name,email}")
 	parser.add_option("--commit-date-earliest", default=False, action="store_true",
-			  help="Commits have timestamp of earliest delta, not (default) latest.")
+			  help="Commits have timestamp of earliest delta, not (default) latest")
 	parser.add_option("--dirs",
 			  action="store_true",
 			  help=("Command-line arguments are a list "
@@ -1170,11 +1170,11 @@ def ParseOptions(argv):
 			  help=("set the number of hours between timezones for"
 				" --move-date, old to new"))
 	parser.add_option("--no-combine-create", default=False, action="store_true",
-			  help="Don't combine file create deltas with date-divergent comments.")
+			  help="Don't combine file create deltas with date-divergent comments")
 	parser.add_option("--no-combine-separate", default=False, action="store_true",
-			  help="Don't combine similar deltas not contiguous in time.")
+			  help="Don't combine similar deltas not contiguous in time")
 	parser.add_option("--no-tags", default=False, action="store_true",
-			  help="Don't try to create tags on SID level bumps.")
+			  help="Don't try to create tags on SID level bumps")
 	parser.add_option("--stdout", default=False, action="store_true",
 			  help=("Send git-fast-import data to stdout "
 				"rather than to git-fast-import"))
@@ -1182,9 +1182,9 @@ def ParseOptions(argv):
 			  help=("Use the 'sccs' front-end for SCCS commands"
 				" (by default need for 'sccs' is auto-detected)"))
 	parser.add_option("--debug", default=False, action="store_true",
-			  help="Print all commands being run and any stderr output.")
+			  help="Print all commands being run and any stderr output")
 	parser.add_option("--verbose", default=False, action="store_true",
-			  help="Print more verbose status messages.")
+			  help="Print more verbose status messages")
 
 	(options, args) = parser.parse_args(argv)
 

--- a/git-sccsimport.py
+++ b/git-sccsimport.py
@@ -158,6 +158,7 @@ debug = False
 verbose = False
 
 DoTags = True
+DoCombineCreate = True
 
 class ImportFailure(Exception):
 	pass
@@ -475,7 +476,7 @@ class Delta(object):
 		self._parent_seqno = int(self._parent_seqno)
 		if self._comment == "\n":
 			self._comment = self._cmp_comment = None
-		elif self._parent_seqno == 0:	# Only for file creation delta
+		elif DoCombineCreate and self._parent_seqno == 0:	# Only for file creation delta
 			# Remove the variable part (the date/time) from a default file
 			# creation comment when used for fuzzy comparison,
 			# and replace with SCCS_ESCAPE as a sentinal unlikely to appear in
@@ -1087,6 +1088,7 @@ def ParseOptions(argv):
 	global MoveDate
 	global MoveOffset
 	global DoTags
+	global DoCombineCreate
 	global verbose
 	global AuthorMap
 
@@ -1125,6 +1127,8 @@ def ParseOptions(argv):
 	parser.add_option("--move-offset",
 			  help=("set the number of hours between timezones for"
 				" --move-date, old to new"))
+	parser.add_option("--no-combine-create", default=False, action="store_true",
+			  help="Don't combine file create deltas with date-divergent comments.")
 	parser.add_option("--no-tags", default=False, action="store_true",
 			  help="Don't try to create tags on SID level bumps.")
 	parser.add_option("--stdout", default=False, action="store_true",
@@ -1174,12 +1178,16 @@ def ParseOptions(argv):
 	if options.authormap:
 		AuthorMap = GetAuthorMap(options.authormap)
 
+	if options.no_combine_create:
+		DoCombineCreate = False
+
 	try:
 		FUZZY_WINDOW = float(options.fuzzy_commit_window)
 	except ValueError:
 		raise UsageError("The argument for the --fuzzy-commit-window option "
 				 "should be a number, but you specified '%s'"
 				 % (options.fuzzy_commit_window,))
+
 	IMPORT_REF = "refs/heads/%s" % (options.branch,)
 	return options, args
 


### PR DESCRIPTION
SCCS deltas for initial file creation have a default comment containing a date string, such as:

 `date and time created 25/01/31 13:49:52 by teliseo`

This causes the fuzzy matching which combines deltas to fail, so that each file create becomes a separate git commit. This pull request fixes this, allowing them to compare equal.

However, because all file creations are now more similar, it might be a good idea to adjust the default --fuzzy-commit-window down from one week to something like a few hours, at most.